### PR TITLE
Create a `MainMediaGallery` component (#13992)

### DIFF
--- a/dotcom-rendering/src/components/MainMediaGallery.stories.tsx
+++ b/dotcom-rendering/src/components/MainMediaGallery.stories.tsx
@@ -1,0 +1,33 @@
+import type { Meta, StoryObj } from '@storybook/react';
+import { gridContainerDecorator } from '../../.storybook/decorators/gridDecorators';
+import { images } from '../../fixtures/generated/images';
+import { ArticleDesign, ArticleDisplay, Pillar } from '../lib/articleFormat';
+import { MainMediaGallery } from './MainMediaGallery';
+
+const meta = {
+	title: 'Components/MainMediaGallery',
+	component: MainMediaGallery,
+	decorators: gridContainerDecorator,
+} satisfies Meta<typeof MainMediaGallery>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default = {
+	args: {
+		mainMedia: images[0],
+		format: {
+			design: ArticleDesign.Gallery,
+			display: ArticleDisplay.Standard,
+			theme: Pillar.News,
+		},
+	},
+} satisfies Story;
+
+export const PortraitImage = {
+	args: {
+		...Default.args,
+		mainMedia: images[7],
+	},
+};

--- a/dotcom-rendering/src/components/MainMediaGallery.tsx
+++ b/dotcom-rendering/src/components/MainMediaGallery.tsx
@@ -1,0 +1,51 @@
+import { css } from '@emotion/react';
+import { from } from '@guardian/source/foundations';
+import { grid } from '../grid';
+import { type ArticleFormat } from '../lib/articleFormat';
+import { getImage } from '../lib/image';
+import { type ImageBlockElement } from '../types/content';
+import { Picture } from './Picture';
+
+type Props = {
+	mainMedia: ImageBlockElement;
+	format: ArticleFormat;
+};
+
+const styles = css`
+	${grid.column.all}
+	height: calc(80vh - 48px);
+	grid-row: 1/5;
+	${from.desktop} {
+		height: calc(100vh - 48px);
+	}
+`;
+
+export const MainMediaGallery = ({ mainMedia, format }: Props) => {
+	const asset = getImage(mainMedia.media.allImages);
+
+	if (asset === undefined) {
+		return null;
+	}
+
+	const width = parseInt(asset.fields.width, 10);
+	const height = parseInt(asset.fields.height, 10);
+
+	if (isNaN(width) || isNaN(height)) {
+		return null;
+	}
+
+	return (
+		<figure css={styles}>
+			<Picture
+				alt={mainMedia.data.alt ?? ''}
+				format={format}
+				role={mainMedia.role}
+				master={asset.url}
+				width={width}
+				height={height}
+				loading="eager"
+				isMainMedia={true}
+			/>
+		</figure>
+	);
+};

--- a/dotcom-rendering/src/components/Picture.tsx
+++ b/dotcom-rendering/src/components/Picture.tsx
@@ -137,32 +137,35 @@ const decideImageWidths = ({
 		];
 	}
 	if (isMainMedia) {
+		if (
+			format.display === ArticleDisplay.Immersive ||
+			format.design === ArticleDesign.Gallery
+		) {
+			// If display is Immersive then main media should *always*
+			// use these larger image sources
+			return [
+				{ breakpoint: breakpoints.mobile, width: 480 },
+				{
+					breakpoint: breakpoints.mobileLandscape,
+					width: 660,
+				},
+				{
+					breakpoint: breakpoints.phablet,
+					width: 740,
+				},
+				{ breakpoint: breakpoints.tablet, width: 980 },
+				{
+					breakpoint: breakpoints.desktop,
+					width: 1140,
+				},
+				{
+					breakpoint: breakpoints.leftCol,
+					width: 1300,
+				},
+				{ breakpoint: breakpoints.wide, width: 1900 },
+			];
+		}
 		switch (format.display) {
-			case ArticleDisplay.Immersive: {
-				// If display is Immersive then main media should *always*
-				// use these larger image sources
-				return [
-					{ breakpoint: breakpoints.mobile, width: 480 },
-					{
-						breakpoint: breakpoints.mobileLandscape,
-						width: 660,
-					},
-					{
-						breakpoint: breakpoints.phablet,
-						width: 740,
-					},
-					{ breakpoint: breakpoints.tablet, width: 980 },
-					{
-						breakpoint: breakpoints.desktop,
-						width: 1140,
-					},
-					{
-						breakpoint: breakpoints.leftCol,
-						width: 1300,
-					},
-					{ breakpoint: breakpoints.wide, width: 1900 },
-				];
-			}
 			case ArticleDisplay.Showcase:
 			case ArticleDisplay.NumberedList: {
 				if (format.design === ArticleDesign.Feature) {
@@ -462,6 +465,19 @@ export const Sources = ({ sources }: { sources: ImageSource[] }) => {
 	);
 };
 
+const styles = ({ design }: ArticleFormat, isLightbox: boolean) => {
+	if (design === ArticleDesign.Gallery) {
+		return css`
+			img {
+				width: 100%;
+				height: 100%;
+				object-fit: cover;
+			}
+		`;
+	}
+	return isLightbox ? flex : block;
+};
+
 export const Picture = ({
 	role,
 	format,
@@ -523,7 +539,7 @@ export const Picture = ({
 	const fallbackSource = getFallbackSource(sources);
 
 	return (
-		<picture css={isLightbox ? flex : block}>
+		<picture css={styles(format, isLightbox)}>
 			{/* Immersive Main Media images get additional sources specifically for when in portrait orientation */}
 			{format.display === ArticleDisplay.Immersive && isMainMedia && (
 				<>

--- a/dotcom-rendering/src/lib/image.ts
+++ b/dotcom-rendering/src/lib/image.ts
@@ -78,3 +78,20 @@ export const generateImageURL = ({
 		url.pathname
 	}?${params.toString()}`;
 };
+
+export const isSupported = (imageUrl: string): boolean => {
+	const supportedImages = ['jpg', 'jpeg', 'png', 'gif'];
+	return supportedImages.some((extension) =>
+		imageUrl.endsWith(`.${extension}`),
+	);
+};
+
+export const getImage = (images: Image[]): Image | undefined => {
+	const image = getMaster(images) ?? getLargest(images);
+
+	if (image?.url === undefined || !isSupported(image.url)) {
+		return undefined;
+	}
+
+	return image;
+};

--- a/dotcom-rendering/src/types/article.ts
+++ b/dotcom-rendering/src/types/article.ts
@@ -1,3 +1,4 @@
+import { isUndefined } from '@guardian/libs';
 import type { FEArticle } from '../frontend/feArticle';
 import {
 	ArticleDesign,
@@ -40,6 +41,7 @@ export type ArticleFields = {
 export type Gallery = ArticleFields & {
 	design: ArticleDesign.Gallery;
 	images: ImageBlockElement[];
+	mainMedia: ImageBlockElement;
 };
 
 export type OtherArticles = ArticleFields & {
@@ -81,6 +83,19 @@ export const enhanceArticleType = (
 
 	if (format.design === ArticleDesign.Gallery) {
 		const design = ArticleDesign.Gallery;
+
+		const mainMedia = mainMediaElements[0];
+		if (isUndefined(mainMedia)) {
+			throw new Error('No main media found');
+		}
+
+		if (
+			mainMedia._type !==
+			'model.dotcomrendering.pageElements.ImageBlockElement'
+		) {
+			throw new Error('Main media is not an image');
+		}
+
 		return {
 			frontendData: {
 				...data,
@@ -110,6 +125,7 @@ export const enhanceArticleType = (
 						'model.dotcomrendering.pageElements.ImageBlockElement',
 				),
 			),
+			mainMedia,
 		};
 	}
 


### PR DESCRIPTION
* Add stories snippet to dcr.code-snippets




* Add main media to gallery model




* Add a basic hello world story for MainMediaGallery component




* MainMediaGallery renders picture sources




* MainMediaGallery uses Picture component




* Revert dcr.code-snippets




* MainMediaGallery PortraitImage story




---------

## What does this change?

## Why?

## Screenshots

| Before      | After      |
| ----------- | ---------- |
| ![before][] | ![after][] |

[before]: https://example.com/before.png
[after]: https://example.com/after.png

<!--
You can add extra rows by repeating the last row in the table and then using new unique labels. E.g.

| ![before2][] | ![after2][] |

You can then reference the labels and map them to corresponding links.

[before2]: https://example.com/before2.png
[after2]: https://example.com/after2.png
-->

<!--
## Running Chromatic

In order to run Chromatic as part of the CI checks, you will need to add the `run_chromatic` label to your PR. Once the label is added Chromatic will run on every push.

Please only add this once you are ready to check for visual regressions, our intention here is to reduce the amount of time Chromatic is run without being looked at.
-->

<!--
## Unexplained Chromatic diffs

We use Chromatic for visual regression testing on our Storybook stories. It's
generally pretty good, but it sometimes gives 'false positives' -- it seems to
detect a change in a component which hasn't changed, or which hasn't been
affected by the code in your PR.

If you've looked at the Chromatic diffs and can't see any connection to your
code, please reach out to a member of the Web Experiences team, who will be able
to advise. It would also be helpful to add the false positive to our
[ongoing log of false positives](https://docs.google.com/spreadsheets/d/1FvItNTMFXIpI4rCrZ4mQ0CRouT06sSVro168f6oKPm4/edit?usp=drive_open&ouid=117150399571694275917#gid=0).
-->
